### PR TITLE
Remove factory girl syntax methods from RSpec config

### DIFF
--- a/lib/g5_authenticatable/test/request_helpers.rb
+++ b/lib/g5_authenticatable/test/request_helpers.rb
@@ -17,7 +17,7 @@ end
 shared_context 'auth request', auth_request: true do
   include G5Authenticatable::Test::RequestHelpers
 
-  let(:user) { create(:g5_authenticatable_user) }
+  let(:user) { FactoryGirl.create(:g5_authenticatable_user) }
 
   before { login_user(user) }
   after { logout_user }

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Signing in' do
-  let(:user) { create(:g5_authenticatable_user) }
+  let(:user) { FactoryGirl.create(:g5_authenticatable_user) }
 
   context 'from a login link' do
     subject(:login) { click_link 'Login' }

--- a/spec/models/g5_authenticatable/user_spec.rb
+++ b/spec/models/g5_authenticatable/user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe G5Authenticatable::User do
   subject { user }
   let(:user) { G5Authenticatable::User.create(user_attributes) }
-  let(:user_attributes) { attributes_for(:g5_authenticatable_user) }
+  let(:user_attributes) { FactoryGirl.attributes_for(:g5_authenticatable_user) }
 
   it 'should expose the email' do
     expect(user.email).to eq(user_attributes[:email])

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,5 +1,0 @@
-require 'factory_girl_rails'
-
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end


### PR DESCRIPTION
Some of the shared test helpers were using unqualified factory method names (e.g. `create` instead of
`FactoryGirl.create`), but client apps should not be required to mixin `FactoryGirl::Syntax::Methods`.
