### PR TITLE
Filter access_token from the implementing app's logs.

### DIFF
--- a/lib/g5_authenticatable/engine.rb
+++ b/lib/g5_authenticatable/engine.rb
@@ -7,5 +7,9 @@ module G5Authenticatable
       g.test_framework :rspec
       g.fixture_replacement :factory_girl, dir: 'spec/factories'
     end
+
+    initializer "g5_authenticatable.filter_access_token" do |app|
+      app.config.filter_parameters += [ :access_token ]
+    end
   end
 end

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe "Application Configuration" do
+  it "appends access_token to the implementing apps filter_parameters" do
+    expect(Dummy::Application.config.filter_parameters).to include(:access_token)
+  end
+end


### PR DESCRIPTION
I noticed the `access_token` in Honeybadger, which I think will get removed if we do this. I'll find out. Either way this is probably a good idea, unless you can think of a reason not to?
