### PR TITLE
Bump session timeout to 12 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.1.pre.1 (2017-07-25)
+
+* Extend session timeout to 12 hours
+  ([#51](https://github.com/G5/g5_authenticatable/pull/51))
+
 ## v0.9.0 (2016-11-03)
 
 * Refactor custom mapping logic into devise_g5_authenticatable callbacks

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ library in isolation.
 
 ## Current Version
 
-0.9.0
+0.9.1.pre.1
 
 ## Requirements
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -145,7 +145,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 1.hour
+  config.timeout_in = 12.hours
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false

--- a/lib/g5_authenticatable/version.rb
+++ b/lib/g5_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module G5Authenticatable
-  VERSION = '0.9.0'
+  VERSION = '0.9.1-1'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,6 @@
 require 'simplecov'
 SimpleCov.start 'test_frameworks'
 
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment", __FILE__)
 


### PR DESCRIPTION
The auth server session timeout is set to 24 hours, and the client app session timeout is set to 12 hours. This discrepancy is intended to avoid the case where a client app maintains an active session beyond the lifespan of the central auth session.

https://www.pivotaltracker.com/story/show/147972967
