### PR TITLE
Rolify rails5

### DIFF
--- a/app/models/g5_authenticatable/role.rb
+++ b/app/models/g5_authenticatable/role.rb
@@ -4,7 +4,7 @@ module G5Authenticatable
   # A user role (e.g. admin, viewer), optionally scoped to a client or location
   class Role < ActiveRecord::Base
     has_and_belongs_to_many :users, join_table: :g5_authenticatable_users_roles
-    belongs_to :resource, polymorphic: true
+    belongs_to :resource, polymorphic: true, optional: true
 
     scopify
   end

--- a/app/models/g5_authenticatable/role.rb
+++ b/app/models/g5_authenticatable/role.rb
@@ -4,7 +4,12 @@ module G5Authenticatable
   # A user role (e.g. admin, viewer), optionally scoped to a client or location
   class Role < ActiveRecord::Base
     has_and_belongs_to_many :users, join_table: :g5_authenticatable_users_roles
-    belongs_to :resource, polymorphic: true, optional: true
+
+    if Rails::VERSION::MAJOR >= 5
+      belongs_to :resource, polymorphic: true, optional: true
+    else
+      belongs_to :resource, polymorphic: true
+    end
 
     scopify
   end

--- a/g5_authenticatable.gemspec
+++ b/g5_authenticatable.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'devise_g5_authenticatable', '1.0.0.pre.1'
   spec.add_dependency 'g5_authenticatable_api', '1.0.0.pre.1'
-  spec.add_dependency 'rolify', '~> 4.0'
+  spec.add_dependency 'rolify', '~> 5.1.0'
   spec.add_dependency 'pundit', '~> 1.0'
   spec.add_dependency 'g5_updatable', '> 0.6.0'
 


### PR DESCRIPTION
* upgrades rolify to rails 5 compatable version (5.1.0)
* fixes issue in rails 5 which was preventing roles from being persisted to the db
(https://github.com/RolifyCommunity/rolify/issues/381)