### PR TITLE
removing updateble factory as it leads to non-unique factory errors

### DIFF
--- a/lib/g5_authenticatable/test/factory.rb
+++ b/lib/g5_authenticatable/test/factory.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'factory_girl_rails'
-require 'g5_updatable/factories'
 require 'g5_authenticatable/test/factories/roles'
 require 'g5_authenticatable/test/factories/global_users'
 require 'g5_authenticatable/test/factories/client_users'

--- a/lib/g5_authenticatable/version.rb
+++ b/lib/g5_authenticatable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module G5Authenticatable
-  VERSION = '1.0.0-3'
+  VERSION = '1.0.0-4'
 end


### PR DESCRIPTION
Including this gem in g5-call-tracking was resulting in duplicate factory definition errors. It seems that requiring g5_updatable/factories in this gem and *require 'g5_updatable/rspec'* in the rails-helper of the rails app causes the issue.