### PR TITLE
Re-enable test coverage in Codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,15 @@ cache:
 before_install:
   - gem install bundler
 before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   - cp spec/dummy/config/database.yml.ci spec/dummy/config/database.yml
   - RAILS_ENV=test bundle exec rake app:db:create app:db:migrate
 script:
   - bundle exec rspec spec
 after_script:
+  - ./cc-test-reporter after-build --exit-code $EXIT_CODE
   - RAILS_ENV=test bundle exec rake app:db:drop
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'codeclimate-test-reporter'
   gem 'generator_spec'
   gem 'rspec-activemodel-mocks'
   gem 'shoulda-matchers', '~> 3.1'

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -17,7 +17,6 @@ end
 
 group :test do
   gem "capybara"
-  gem "codeclimate-test-reporter"
   gem "generator_spec"
   gem "rspec-activemodel-mocks"
   gem "shoulda-matchers", "~> 3.1"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -17,7 +17,6 @@ end
 
 group :test do
   gem "capybara"
-  gem "codeclimate-test-reporter"
   gem "generator_spec"
   gem "rspec-activemodel-mocks"
   gem "shoulda-matchers", "~> 3.1"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -17,7 +17,6 @@ end
 
 group :test do
   gem "capybara"
-  gem "codeclimate-test-reporter"
   gem "generator_spec"
   gem "rspec-activemodel-mocks"
   gem "shoulda-matchers", "~> 3.1"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -17,7 +17,6 @@ end
 
 group :test do
   gem "capybara"
-  gem "codeclimate-test-reporter"
   gem "generator_spec"
   gem "rspec-activemodel-mocks"
   gem "shoulda-matchers", "~> 3.1"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -17,7 +17,6 @@ end
 
 group :test do
   gem "capybara"
-  gem "codeclimate-test-reporter"
   gem "generator_spec"
   gem "rspec-activemodel-mocks"
   gem "shoulda-matchers", "~> 3.1"

--- a/spec/models/g5_authenticatable/user_spec.rb
+++ b/spec/models/g5_authenticatable/user_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe G5Authenticatable::User do
       end
 
       it 'should not change the user roles' do
-        expect { updated_user }.to_not change { user.reload.roles }
+        expect { updated_user }.to_not change { user.roles.reload.to_a }
       end
     end
 


### PR DESCRIPTION
We were using an elderly version of the test reporter client that is no longer supported by their API.