### PR TITLE
Fix factorybot factories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ sudo: false
 cache:
   bundler: true
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.1 (2020-03-21)
+* Fixing FactoryBotFactories to actual work with FactoryBot
+* Apps using FactoryBot that include this gem blow up when loading g5_authenticatable's factories
+because assignments require the new `{}` syntax 
+
+
 ## v1.2.0 (2020-01-24)
 * Adding `User.find_or_create_from_access_token_request` to support access_token-based Pundit authorization
 ## v1.1.2 (2018-12-20)

--- a/lib/g5_authenticatable/test/factories/client_users.rb
+++ b/lib/g5_authenticatable/test/factories/client_users.rb
@@ -3,9 +3,9 @@
 FactoryBot.define do
   factory :g5_authenticatable_client_user, parent: :g5_authenticatable_user do
     transient do
-      clients nil
-      client_count 1
-      role_factory :g5_authenticatable_client_role
+      clients {nil}
+      client_count {1}
+      role_factory { :g5_authenticatable_client_role}
     end
 
     after(:create) do |user, evaluator|
@@ -25,21 +25,21 @@ FactoryBot.define do
   factory :g5_authenticatable_client_admin,
           parent: :g5_authenticatable_client_user do
     transient do
-      role_factory :g5_authenticatable_client_admin_role
+      role_factory {:g5_authenticatable_client_admin_role}
     end
   end
 
   factory :g5_authenticatable_client_editor,
           parent: :g5_authenticatable_client_user do
     transient do
-      role_factory :g5_authenticatable_client_editor_role
+      role_factory {:g5_authenticatable_client_editor_role}
     end
   end
 
   factory :g5_authenticatable_client_viewer,
           parent: :g5_authenticatable_client_user do
     transient do
-      role_factory :g5_authenticatable_client_viewer_role
+      role_factory {:g5_authenticatable_client_viewer_role}
     end
   end
 end

--- a/lib/g5_authenticatable/test/factories/global_users.rb
+++ b/lib/g5_authenticatable/test/factories/global_users.rb
@@ -3,14 +3,14 @@
 FactoryBot.define do
   factory :g5_authenticatable_user, class: 'G5Authenticatable::User' do
     sequence(:email) { |n| "test.user#{n}@test.host" }
-    provider 'g5'
+    provider {'g5'}
     sequence(:uid) { |n| "abc123-#{n}" }
     sequence(:g5_access_token) { |n| "secret_token_#{n}" }
-    first_name 'Jane'
-    last_name 'Doe'
-    phone_number '(555) 867-5309'
-    title 'Minister of Funny Walks'
-    organization_name 'Department of Redundancy Department'
+    first_name {'Jane'}
+    last_name {'Doe'}
+    phone_number {'(555) 867-5309'}
+    title {'Minister of Funny Walks'}
+    organization_name {'Department of Redundancy Department'}
   end
 
   factory :g5_authenticatable_super_admin, parent: :g5_authenticatable_user do

--- a/lib/g5_authenticatable/test/factories/location_users.rb
+++ b/lib/g5_authenticatable/test/factories/location_users.rb
@@ -3,9 +3,9 @@
 FactoryBot.define do
   factory :g5_authenticatable_location_user, parent: :g5_authenticatable_user do
     transient do
-      locations nil
-      location_count 1
-      role_factory :g5_authenticatable_location_role
+      locations {nil}
+      location_count {1}
+      role_factory {:g5_authenticatable_location_role}
     end
 
     after(:create) do |user, evaluator|
@@ -25,21 +25,21 @@ FactoryBot.define do
   factory :g5_authenticatable_location_admin,
           parent: :g5_authenticatable_location_user do
     transient do
-      role_factory :g5_authenticatable_location_admin_role
+      role_factory {:g5_authenticatable_location_admin_role}
     end
   end
 
   factory :g5_authenticatable_location_editor,
           parent: :g5_authenticatable_location_user do
     transient do
-      role_factory :g5_authenticatable_location_editor_role
+      role_factory {:g5_authenticatable_location_editor_role}
     end
   end
 
   factory :g5_authenticatable_location_viewer,
           parent: :g5_authenticatable_location_user do
     transient do
-      role_factory :g5_authenticatable_location_viewer_role
+      role_factory {:g5_authenticatable_location_viewer_role}
     end
   end
 end

--- a/lib/g5_authenticatable/test/factories/roles.rb
+++ b/lib/g5_authenticatable/test/factories/roles.rb
@@ -7,19 +7,19 @@ FactoryBot.define do
 
   factory :g5_authenticatable_super_admin_role,
           parent: :g5_authenticatable_role do
-    name 'super_admin'
+    name {'super_admin'}
   end
 
   factory :g5_authenticatable_admin_role, parent: :g5_authenticatable_role do
-    name 'admin'
+    name {'admin'}
   end
 
   factory :g5_authenticatable_editor_role, parent: :g5_authenticatable_role do
-    name 'editor'
+    name {'editor'}
   end
 
   factory :g5_authenticatable_viewer_role, parent: :g5_authenticatable_role do
-    name 'viewer'
+    name {'viewer'}
   end
 
   factory :g5_authenticatable_client_role, parent: :g5_authenticatable_role do
@@ -28,17 +28,17 @@ FactoryBot.define do
 
   factory :g5_authenticatable_client_admin_role,
           parent: :g5_authenticatable_client_role do
-    name 'admin'
+    name {'admin'}
   end
 
   factory :g5_authenticatable_client_editor_role,
           parent: :g5_authenticatable_client_role do
-    name 'editor'
+    name {'editor'}
   end
 
   factory :g5_authenticatable_client_viewer_role,
           parent: :g5_authenticatable_client_role do
-    name 'viewer'
+    name {'viewer'}
   end
 
   factory :g5_authenticatable_location_role,
@@ -48,16 +48,16 @@ FactoryBot.define do
 
   factory :g5_authenticatable_location_admin_role,
           parent: :g5_authenticatable_location_role do
-    name 'admin'
+    name {'admin'}
   end
 
   factory :g5_authenticatable_location_editor_role,
           parent: :g5_authenticatable_location_role do
-    name 'editor'
+    name {'editor'}
   end
 
   factory :g5_authenticatable_location_viewer_role,
           parent: :g5_authenticatable_location_role do
-    name 'viewer'
+    name {'viewer'}
   end
 end

--- a/lib/g5_authenticatable/version.rb
+++ b/lib/g5_authenticatable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module G5Authenticatable
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
If an app that uses FactoryBot includes this gem and adds `require 'g5_authenticatable/rspec'` to its rails_helper.rb, it will blow up because "factorybot" factories don't use factorybot syntax