### PR TITLE
Rails 6.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v1.2.2 (2021-02-03)
+* Render files the Rails 6 way https://github.com/G5/g5_authenticatable/pull/66
 ## v1.2.1 (2020-04-10)
 * Syntax updates so included factories work with newer versions of FactoryBot
 ## v1.2.0 (2020-01-24)

--- a/app/assets/config/g5_authenticatable_manifest.js
+++ b/app/assets/config/g5_authenticatable_manifest.js
@@ -1,0 +1,1 @@
+//= link_directory ../stylesheets/g5_authenticatable .css

--- a/app/controllers/concerns/g5_authenticatable/authorization.rb
+++ b/app/controllers/concerns/g5_authenticatable/authorization.rb
@@ -16,7 +16,7 @@ module G5Authenticatable
           render status: :forbidden, json: { error: 'Access forbidden' }
         end
         format.html do
-          render status: :forbidden, file: "#{Rails.root}/public/403"
+          render status: :forbidden, file: Rails.root.join('public', '403.html')
         end
       end
     end

--- a/lib/g5_authenticatable/version.rb
+++ b/lib/g5_authenticatable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module G5Authenticatable
-  VERSION = '1.2.2.pre.1'
+  VERSION = '1.2.2'
 end

--- a/lib/g5_authenticatable/version.rb
+++ b/lib/g5_authenticatable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module G5Authenticatable
-  VERSION = '1.2.1'
+  VERSION = '1.2.2.pre.1'
 end


### PR DESCRIPTION
Rails 6.1 requires a new render file argument. 

This is getting pushed to gemfury as `1.2.2.pre.1` for now so that Rails 6.1 upgrade efforts can use it. 

If other Rails 6 related bugs pop up, developers should update this branch.